### PR TITLE
Fix "Keep A Changelog" version detection

### DIFF
--- a/github-release-from-changelog.js
+++ b/github-release-from-changelog.js
@@ -126,7 +126,7 @@ changelogLines.some(function(line, i) {
   if (
     !start &&
     (line.indexOf("# " + version) === 0 ||
-      (isKeepAChangelogFormat && line.indexOf("## [") === 0))
+      (isKeepAChangelogFormat && line.indexOf("## [" + version) === 0))
   ) {
     start = true;
   } else if (

--- a/github-release-from-changelog.js
+++ b/github-release-from-changelog.js
@@ -132,9 +132,10 @@ changelogLines.some(function(line, i) {
   } else if (
     start &&
     (line.indexOf("# ") === 0 ||
-      (isKeepAChangelogFormat && line.indexOf("## [") === 0))
+      (isKeepAChangelogFormat && line.indexOf("## [") === 0) ||
+      (line.indexOf("[") === 0))
   ) {
-    // end with another # version
+    // end with another # version or a footer link
     return true;
   } else if (start) {
     // between start & end, collect lines


### PR DESCRIPTION
This builds off the work in #11 by detecting the "Keep A Changelog" version block using the version specified in `package.json`. In my [project](https://github.com/igetgames/grommet-playground), my CHANGELOG.md is formatted as follows:

```markdown
# Changelog

...

## [Unreleased]

...

## [0.1.2] - 2018-01-20

...

[Unreleased]: [...]
[0.1.2]: [...]
...
```

Without this patch, github-release-from-changelog will start the change block at `## [Unreleased]` even though the version is "0.1.2" in `package.json`. The patch will also end change block detection at the first line beginning with "[", which assumes that the line begins a block of links in the footer of the changelog.