### PR TITLE
fix: report config errors cleanly and accept repository shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # `github-release-from-changelog` Changelog
 
+## Unreleased
+
+- 🐛 Report configuration errors as clean messages instead of Node
+  uncaught-exception dumps (errors were thrown as bare strings)
+- ✨ Accept the npm shorthand `repository` forms (`"user/repo"` and
+  `"github:user/repo"`) in addition to full GitHub urls; the
+  "Unable to parse repository url" message now shows the offending value and
+  the expected format
+
 ## 3.0.0 - 2026-06-02
 
 ⚠️ Breaking changes (CLI usage unchanged):

--- a/github-release-from-changelog.js
+++ b/github-release-from-changelog.js
@@ -6,6 +6,13 @@ import process from "node:process";
 import minimist from "minimist";
 import grizzly from "grizzly";
 
+// Report a user-facing error without the uncaught-exception noise Node prints
+// for a bare `throw`, then exit with a failure code.
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
 const changelogFileNames = [
   "CHANGELOG.md",
   "Changelog.md",
@@ -59,7 +66,7 @@ let pkg;
 try {
   pkg = JSON.parse(fs.readFileSync(process.cwd() + "/package.json", "utf8"));
 } catch {
-  throw "No package.json found in " + process.cwd();
+  fail("No package.json found in " + process.cwd());
 }
 
 // read changelog
@@ -69,22 +76,43 @@ try {
     encoding: "utf8",
   });
 } catch {
-  throw "No " + changelogFileName + " found in " + process.cwd();
+  fail("No " + changelogFileName + " found in " + process.cwd());
 }
 
-// parse repository url to get user & repo slug
+// parse the repository field to get the user & repo slug
+// supports full git/https/ssh GitHub urls as well as the npm shorthands
+// "user/repo" and "github:user/repo"
 let repoUrl = pkg.repository;
 if (repoUrl === undefined) {
-  throw "No repository.url found in " + process.cwd() + "/repository(.url)";
+  fail("No `repository` field found in " + process.cwd() + "/package.json");
 }
 if (typeof repoUrl === "object" && repoUrl.url) {
   repoUrl = repoUrl.url;
 }
-const matches = repoUrl.match(/(?:https?|git(?:\+ssh)?)(?::\/\/)(?:www\.)?github\.com\/(.*)/i);
-if (matches === null) {
-  throw "Unable to parse repository url";
+if (typeof repoUrl !== "string") {
+  fail("Unable to read the `repository` field in package.json");
 }
-const repoData = matches[1].split("/");
+
+// drop an optional npm host shorthand prefix, e.g. "github:user/repo"
+repoUrl = repoUrl.replace(/^github:/i, "");
+
+let slug;
+const urlMatches = repoUrl.match(/github\.com[/:]([^/]+\/[^/]+?)(?:\.git)?\/?$/i);
+if (urlMatches) {
+  slug = urlMatches[1];
+} else if (/^[^/]+\/[^/]+$/.test(repoUrl)) {
+  // npm shorthand: "user/repo"
+  slug = repoUrl;
+} else {
+  fail(
+    'Unable to parse repository url "' +
+      repoUrl +
+      '". Expected a GitHub url (e.g. "https://github.com/user/repo.git") ' +
+      'or the npm shorthand "user/repo".',
+  );
+}
+
+const repoData = slug.split("/");
 const user = repoData[0];
 const repo = repoData[1].replace(/\.git$/, "");
 
@@ -96,7 +124,7 @@ const tags = cp.execSync("git tag", { encoding: "utf8" });
 const tagMatches = tags.match(new RegExp("^(v?)" + version + "$", "gm"));
 let tagName;
 if (tagMatches === null) {
-  throw "Tag " + version + " or v" + version + " not found";
+  fail("Tag " + version + " or v" + version + " not found");
 } else {
   tagName = tagMatches[0];
 }
@@ -155,7 +183,7 @@ if (argv.dryRun) {
 } else {
   const token = process.env.GITHUB_TOKEN;
   if (!token) {
-    throw "GITHUB_TOKEN required";
+    fail("GITHUB_TOKEN required");
   }
 
   grizzly(token, releaseOptions).then(


### PR DESCRIPTION
Fixes #31.

## What

Two independent, small improvements to error handling.

### 1. Clean error reporting

Validation failures were raised with bare `throw "string"`. A non-`Error` thrown at the ESM top level is surfaced by Node as an *uncaught exception*, with `triggerUncaughtException` / `node:internal/...` frames and a `--trace-uncaught` hint — making a simple misconfiguration look like a tool crash.

They now go through a small `fail()` helper that prints the message to stderr and `process.exit(1)` — mirroring the existing `grizzly(...)` rejection handler.

Before:
```
node:internal/modules/run_main:107
    triggerUncaughtException(
    ^
Unable to parse repository url
(Use `node --trace-uncaught ...` to show where the exception was thrown)

Node.js v24.11.0
```

After:
```
Unable to parse repository url "foo/bar". Expected a GitHub url (e.g. "https://github.com/user/repo.git") or the npm shorthand "user/repo".
```

### 2. Accept the npm `repository` shorthand

The previous regex only matched full `https://github.com/...` urls, so the npm-supported shorthand `"repository": "user/repo"` failed with the opaque "Unable to parse repository url". The parser now accepts:

- `user/repo` and `github:user/repo` (npm shorthands)
- `https://github.com/user/repo(.git)`
- `git@github.com:user/repo.git` (scp-like ssh)
- `git+ssh://git@github.com/user/repo.git`
- the `{ "type": "git", "url": "..." }` object form

and the parse-error message now includes the offending value and expected format.

## Testing

Verified with `--dryRun` against each repository variant above (all resolve to `user/repo`) and each failure path (missing `repository`, non-GitHub url, missing tag) now prints a clean one-line error with exit code 1. `oxlint` and `oxfmt --check` pass.
